### PR TITLE
Adding new PaymentTypeId - MercadoPago is now accepting PayPal

### DIFF
--- a/px-dotnet/Common/PaymentTypeId.cs
+++ b/px-dotnet/Common/PaymentTypeId.cs
@@ -22,6 +22,8 @@ namespace MercadoPago.Common
         ///<summary>Payment by prepaid card</summary>
         prepaid_card,
         ///<summary>Payment by digital currency</summary>
-        digital_currency
+        digital_currency,
+        ///<summary>Payment by digital wallet (e.g. PayPal)</summary>
+        digital_wallet,
     }
 }


### PR DESCRIPTION
MercadoPago is now accepting PayPal, `digital_wallet` is the corresponding PaymentTypeId